### PR TITLE
Defer initial month guardrail adjustments

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -434,7 +434,8 @@ def get_guardrail_withdrawals(
     for i, row in subset.iterrows():
         current_date = row['Date']
         months_remaining = len(subset) - i
-        adjustment_allowed = is_adjustment_month(current_date, settings.adjustment_frequency)
+        is_first_month = i == 0
+        adjustment_allowed = (not is_first_month) and is_adjustment_month(current_date, settings.adjustment_frequency)
 
         status_line = f"Processing {current_date.strftime('%Y-%m')}, portfolio=${current_portfolio_value:,.0f}, months_remaining={months_remaining}"
         if on_status is not None:


### PR DESCRIPTION
## Summary
- prevent guardrail adjustments during the first month so initial spending is always used
- preserve guardrail calculations while deferring spending changes until the second month

## Testing
- python -m compileall utils.py

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920cfd56cf483218d553b2974f38a82)