### PR TITLE
Make rebalancing configurable, and add optional equity glidepath

### DIFF
--- a/app_settings.py
+++ b/app_settings.py
@@ -142,6 +142,8 @@ class Settings:
     spending_cap_option: str
     spending_floor_option: str
     final_value_target: float = 0.0
+    glidepath_initial_pct: float = 0.75
+    glidepath_months: int = 0
     cashflows: List[CashflowSetting] = field(default_factory=list)
     conditional_cashflows: List[ConditionalCashflowSetting] = field(default_factory=list)
 
@@ -164,6 +166,8 @@ class Settings:
         self.spending_cap_option = str(self.spending_cap_option)
         self.spending_floor_option = str(self.spending_floor_option)
         self.final_value_target = float(self.final_value_target)
+        self.glidepath_initial_pct = float(self.glidepath_initial_pct)
+        self.glidepath_months = int(self.glidepath_months)
 
         # Validation
         if self.initial_value <= 0:
@@ -207,6 +211,15 @@ class Settings:
             raise ValueError(
                 f"Final value target ({self.final_value_target:,.0f}) cannot exceed "
                 f"initial portfolio value ({self.initial_value:,.0f})"
+            )
+        if not (0.0 <= self.glidepath_initial_pct <= 1.0):
+            raise ValueError(
+                f"Glidepath initial stock percentage must be between 0% and 100%, "
+                f"got {self.glidepath_initial_pct * 100:.0f}%"
+            )
+        if self.glidepath_months < 0:
+            raise ValueError(
+                f"Glidepath duration must be non-negative, got {self.glidepath_months} months"
             )
 
         # Clean cashflows
@@ -268,6 +281,8 @@ class Settings:
             "initial_monthly_spending": float(self.initial_monthly_spending),
             "initial_spending_overridden": bool(self.initial_spending_overridden),
             "final_value_target": float(self.final_value_target),
+            "glidepath_initial_pct": float(self.glidepath_initial_pct),
+            "glidepath_months": int(self.glidepath_months),
         }
 
     def retirement_end_date(self) -> Optional[dt.date]:
@@ -301,6 +316,8 @@ class Settings:
             "spending_cap_option": self.spending_cap_option,
             "spending_floor_option": self.spending_floor_option,
             "final_value_target": float(self.final_value_target),
+            "glidepath_initial_pct": float(self.glidepath_initial_pct),
+            "glidepath_months": int(self.glidepath_months),
             "cashflows": [flow.to_serializable() for flow in self.cashflows],
             "conditional_cashflows": [flow.to_serializable() for flow in self.conditional_cashflows],
         }
@@ -346,6 +363,8 @@ class Settings:
             spending_cap_option=data.get("spending_cap_option", "Unlimited"),
             spending_floor_option=data.get("spending_floor_option", "Unlimited"),
             final_value_target=data.get("final_value_target", 0.0),
+            glidepath_initial_pct=data.get("glidepath_initial_pct", data.get("stock_pct", 0.75)),
+            glidepath_months=data.get("glidepath_months", 0),
             cashflows=cashflows_clean,
             conditional_cashflows=conditional_clean,
         )
@@ -401,6 +420,8 @@ class Settings:
         session_state["spending_cap_option"] = self.spending_cap_option
         session_state["spending_floor_option"] = self.spending_floor_option
         session_state["final_value_target"] = self.final_value_target
+        session_state["glidepath_initial_pct"] = self.glidepath_initial_pct
+        session_state["glidepath_months"] = self.glidepath_months
         session_state["cashflows"] = [flow.to_serializable() for flow in self.cashflows]
         session_state["conditional_cashflows"] = [flow.to_serializable() for flow in self.conditional_cashflows]
 

--- a/app_settings.py
+++ b/app_settings.py
@@ -138,6 +138,7 @@ class Settings:
     lower_adjustment_fraction: float
     adjustment_threshold: float
     adjustment_frequency: str
+    rebalance_frequency: str
     spending_cap_option: str
     spending_floor_option: str
     final_value_target: float = 0.0
@@ -159,6 +160,7 @@ class Settings:
         self.lower_adjustment_fraction = float(self.lower_adjustment_fraction)
         self.adjustment_threshold = float(self.adjustment_threshold)
         self.adjustment_frequency = str(self.adjustment_frequency)
+        self.rebalance_frequency = str(self.rebalance_frequency)
         self.spending_cap_option = str(self.spending_cap_option)
         self.spending_floor_option = str(self.spending_floor_option)
         self.final_value_target = float(self.final_value_target)
@@ -258,6 +260,7 @@ class Settings:
             "lower_adjustment_fraction": float(self.lower_adjustment_fraction),
             "adjustment_threshold": float(self.adjustment_threshold),
             "adjustment_frequency": self.adjustment_frequency,
+            "rebalance_frequency": self.rebalance_frequency,
             "spending_cap_multiplier": self.spending_cap_multiplier,
             "spending_floor_multiplier": self.spending_floor_multiplier,
             "cashflows": tuple(flow.signature() for flow in self.cashflows),
@@ -294,6 +297,7 @@ class Settings:
             "lower_adjustment_fraction": float(self.lower_adjustment_fraction),
             "adjustment_threshold": float(self.adjustment_threshold),
             "adjustment_frequency": self.adjustment_frequency,
+            "rebalance_frequency": self.rebalance_frequency,
             "spending_cap_option": self.spending_cap_option,
             "spending_floor_option": self.spending_floor_option,
             "final_value_target": float(self.final_value_target),
@@ -338,6 +342,7 @@ class Settings:
             lower_adjustment_fraction=data.get("lower_adjustment_fraction", 0.1),
             adjustment_threshold=data.get("adjustment_threshold", 0.05),
             adjustment_frequency=data.get("adjustment_frequency", "Monthly"),
+            rebalance_frequency=data.get("rebalance_frequency", "Monthly"),
             spending_cap_option=data.get("spending_cap_option", "Unlimited"),
             spending_floor_option=data.get("spending_floor_option", "Unlimited"),
             final_value_target=data.get("final_value_target", 0.0),
@@ -392,6 +397,7 @@ class Settings:
         session_state["lower_adjustment_fraction"] = self.lower_adjustment_fraction
         session_state["adjustment_threshold"] = self.adjustment_threshold
         session_state["adjustment_frequency"] = self.adjustment_frequency
+        session_state["rebalance_frequency"] = self.rebalance_frequency
         session_state["spending_cap_option"] = self.spending_cap_option
         session_state["spending_floor_option"] = self.spending_floor_option
         session_state["final_value_target"] = self.final_value_target
@@ -408,6 +414,7 @@ class Settings:
             "stock_pct": float(self.stock_pct),
             "desired_success_rate": float(self.target_success_rate),
             "final_value_target": float(self.final_value_target),
+            "rebalance_frequency": self.rebalance_frequency,
         }
 
     def to_guardrail_params(self) -> Dict[str, Any]:
@@ -421,4 +428,5 @@ class Settings:
             "lower_sr": float(self.lower_guardrail_success),
             "initial_spending": float(self.initial_monthly_spending),
             "final_value_target": float(self.final_value_target),
+            "rebalance_frequency": self.rebalance_frequency,
         }

--- a/controls.py
+++ b/controls.py
@@ -218,6 +218,8 @@ def initialize_display():
         st.session_state["_initial_spending_overridden"] = False
     if "_initial_spending_auto_value" not in st.session_state:
         st.session_state["_initial_spending_auto_value"] = None
+    if "rebalance_frequency" not in st.session_state:
+        st.session_state["rebalance_frequency"] = "Monthly"
     if "final_value_target" not in st.session_state:
         st.session_state["final_value_target"] = 0.0
 

--- a/controls.py
+++ b/controls.py
@@ -222,6 +222,10 @@ def initialize_display():
         st.session_state["rebalance_frequency"] = "Monthly"
     if "final_value_target" not in st.session_state:
         st.session_state["final_value_target"] = 0.0
+    if "glidepath_initial_pct" not in st.session_state:
+        st.session_state["glidepath_initial_pct"] = 0.75
+    if "glidepath_months" not in st.session_state:
+        st.session_state["glidepath_months"] = 0
 
 
 def draw_cashflow_widget_rows():

--- a/display.py
+++ b/display.py
@@ -36,6 +36,7 @@ def update_isr_dynamic_label(isr_params: dict, cashflows: list):
         verbose=False,
         cashflows=cashflows,
         final_value_target=isr_params.get('final_value_target', 0.0),
+        rebalance_frequency=isr_params.get('rebalance_frequency', 'Monthly'),
     )
     st.session_state['isr_value'] = float(res['spending_rate']) if res['spending_rate'] is not None else None
     st.session_state['isr_params'] = isr_params
@@ -52,6 +53,8 @@ def update_guardrail_dynamic_labels(gr_params: dict, cashflows: list):
     final_value_target = gr_params.get('final_value_target', 0.0)
 
     # Compute spending rates at start of retirement using retirement start date as analysis end date
+    rebalance_frequency = gr_params.get('rebalance_frequency', 'Monthly')
+
     upper_res = utils.get_spending_rate_for_fixed_success_rate(
         df=shiller_df,
         desired_success_rate=gr_params['upper_sr'],
@@ -64,6 +67,7 @@ def update_guardrail_dynamic_labels(gr_params: dict, cashflows: list):
         verbose=False,
         cashflows=cashflows,
         final_value_target=final_value_target,
+        rebalance_frequency=rebalance_frequency,
     )
 
     lower_res = utils.get_spending_rate_for_fixed_success_rate(
@@ -78,6 +82,7 @@ def update_guardrail_dynamic_labels(gr_params: dict, cashflows: list):
         verbose=False,
         cashflows=cashflows,
         final_value_target=final_value_target,
+        rebalance_frequency=rebalance_frequency,
     )
 
     upper_sr = float(upper_res['spending_rate']) if upper_res['spending_rate'] is not None else None

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -9,6 +9,7 @@ import controls
 import display
 import utils
 from app_settings import CashflowSetting, ConditionalCashflowSetting, Settings
+from utils import FREQUENCY_OPTIONS
 
 st.set_page_config(layout="wide", page_title="Guardrail Withdrawal Simulator")
 
@@ -130,6 +131,23 @@ stock_pct = st.sidebar.slider(
     help="Fraction of the portfolio allocated to US stocks; remainder to 10Y treasuries."
 )
 
+current_rebalance = st.session_state.get("rebalance_frequency", "Monthly")
+try:
+    rebalance_index = FREQUENCY_OPTIONS.index(str(current_rebalance))
+except ValueError:
+    rebalance_index = 0
+rebalance_frequency = st.sidebar.selectbox(
+    "Rebalance Frequency",
+    options=FREQUENCY_OPTIONS,
+    index=rebalance_index,
+    key="rebalance_frequency",
+    help="How often the portfolio is rebalanced to its target stock/bond allocation. "
+         "Monthly rebalancing (default) applies a blended return each month. Less frequent "
+         "rebalancing allows the allocation to drift between rebalance dates, which can affect "
+         "results during strong bull or bear markets.",
+    on_change=_unmark_initial_spending_overridden,
+)
+
 cap_options = ["Unlimited"] + [f"{pct}%" for pct in range(100, 201, 5)]
 floor_options = ["Unlimited"] + [f"{pct}%" for pct in range(100, 24, -5)]
 
@@ -150,6 +168,7 @@ isr_params = {
     # Use current target_success_rate if available, otherwise default of 0.90
     'desired_success_rate': float(st.session_state.get('target_success_rate', 0.90)),
     'final_value_target': float(st.session_state.get('final_value_target', 0.0)),
+    'rebalance_frequency': str(st.session_state.get('rebalance_frequency', 'Monthly')),
     'cashflows': controls.cashflows_to_tuple(sanitized_cashflows),
 }
 isr_label_suffix = ""
@@ -248,6 +267,7 @@ try:
         'isr': float(st.session_state.get('isr_value')) if st.session_state.get('isr_value') is not None else None,
         'initial_spending': float(st.session_state.get("initial_monthly_spending", 0.0)),
         'final_value_target': float(st.session_state.get('final_value_target', 0.0)),
+        'rebalance_frequency': str(st.session_state.get('rebalance_frequency', 'Monthly')),
         'cashflows': controls.cashflows_to_tuple(sanitized_cashflows),
     }
 
@@ -349,15 +369,14 @@ adjustment_threshold = st.sidebar.slider(
     disabled=is_guidance  # In Guidance Mode, single-run snapshot ignores threshold
 )
 
-frequency_options = ["Monthly", "Quarterly", "Biannually", "Annually"]
 current_frequency = st.session_state.get("adjustment_frequency", "Monthly")
 try:
-    frequency_index = frequency_options.index(str(current_frequency))
+    frequency_index = FREQUENCY_OPTIONS.index(str(current_frequency))
 except ValueError:
     frequency_index = 0
 adjustment_frequency = st.sidebar.selectbox(
     "Adjustment Frequency",
-    options=frequency_options,
+    options=FREQUENCY_OPTIONS,
     index=frequency_index,
     key="adjustment_frequency",
     help="How often spending adjustments are permitted. Choosing Quarterly, Biannually, or Annually restricts guardrail checks "
@@ -446,6 +465,7 @@ settings = Settings(
     lower_adjustment_fraction=float(lower_adjustment_fraction),
     adjustment_threshold=float(adjustment_threshold),
     adjustment_frequency=adjustment_frequency,
+    rebalance_frequency=rebalance_frequency,
     spending_cap_option=st.session_state.get("spending_cap_option", "Unlimited"),
     spending_floor_option=st.session_state.get("spending_floor_option", "Unlimited"),
     final_value_target=float(st.session_state.get("final_value_target", 0.0)),

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -434,7 +434,7 @@ with st.sidebar.expander("Advanced Controls"):
         disabled=(st.session_state.get("glidepath_months", 0) == 0),
         help="Starting stock allocation at the beginning of retirement. "
              "The allocation linearly shifts to the target Stock Percentage "
-             "over the Glidepath Duration.\n\n"
+             "over the Glidepath Duration, updating at each rebalance date.\n\n"
              "Note: success rate calculations (initial spending rate, guardrail levels, "
              "and guidance) always use the target Stock Percentage, not the glidepath "
              "position. The glidepath only affects month-to-month portfolio returns "

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -416,6 +416,31 @@ with st.sidebar.expander("Advanced Controls"):
              "value approaches zero.",
     )
 
+    st.number_input(
+        "Glidepath Duration (months)",
+        min_value=0, max_value=120, step=12,
+        key="glidepath_months",
+        help="Number of months over which to transition from the glidepath initial "
+             "allocation to the target Stock Percentage. Set to 0 to disable.\n\n"
+             "Note: success rate calculations (initial spending rate, guardrail levels, "
+             "and guidance) always use the target Stock Percentage, not the glidepath "
+             "position. The glidepath only affects month-to-month portfolio returns "
+             "during the simulation.",
+    )
+    st.slider(
+        "Glidepath Initial Stock %",
+        min_value=0.0, max_value=1.0, step=0.01,
+        key="glidepath_initial_pct",
+        disabled=(st.session_state.get("glidepath_months", 0) == 0),
+        help="Starting stock allocation at the beginning of retirement. "
+             "The allocation linearly shifts to the target Stock Percentage "
+             "over the Glidepath Duration.\n\n"
+             "Note: success rate calculations (initial spending rate, guardrail levels, "
+             "and guidance) always use the target Stock Percentage, not the glidepath "
+             "position. The glidepath only affects month-to-month portfolio returns "
+             "during the simulation.",
+    )
+
     if st.button("Add Recurring Cashflow", key="add_cashflow_btn"):
         st.session_state["cashflows"].append({
             "start_month": 0,
@@ -469,6 +494,8 @@ settings = Settings(
     spending_cap_option=st.session_state.get("spending_cap_option", "Unlimited"),
     spending_floor_option=st.session_state.get("spending_floor_option", "Unlimited"),
     final_value_target=float(st.session_state.get("final_value_target", 0.0)),
+    glidepath_initial_pct=float(st.session_state.get("glidepath_initial_pct", 0.75)),
+    glidepath_months=int(st.session_state.get("glidepath_months", 0)),
     cashflows=cashflow_settings,
     conditional_cashflows=conditional_cashflow_settings,
 )

--- a/utils.py
+++ b/utils.py
@@ -9,6 +9,14 @@ import requests
 
 from app_settings import Settings
 
+FREQUENCY_OPTIONS = ["Monthly", "Quarterly", "Biannually", "Annually"]
+
+FREQUENCY_TO_PERIOD = {"Monthly": 1, "Quarterly": 3, "Biannually": 6, "Annually": 12}
+
+
+def frequency_to_period(frequency: str) -> int:
+    return FREQUENCY_TO_PERIOD.get(frequency, 1)
+
 
 def parse_shiller_date(series):
     """
@@ -138,6 +146,59 @@ def compute_portfolio_returns(stock_prices, bond_prices, stock_pct):
     return float(stock_pct) * stock_returns + (1 - float(stock_pct)) * bond_returns
 
 
+def compute_separate_returns(stock_prices, bond_prices):
+    """Compute separate stock and bond return series from price series."""
+    stock_returns = np.ones(len(stock_prices))
+    stock_returns[1:] = stock_prices[1:] / stock_prices[:-1]
+    bond_returns = np.ones(len(bond_prices))
+    bond_returns[1:] = bond_prices[1:] / bond_prices[:-1]
+    return stock_returns, bond_returns
+
+
+@nb.jit(nopython=True)
+def test_all_periods_with_rebalancing(stock_returns, bond_returns, target_stock_frac,
+                                       rebalance_period, num_months, initial_value,
+                                       monthly_spending, monthly_cashflows, final_value_target):
+    """
+    Run all paths with portfolio drift between rebalance dates.
+
+    Between rebalancing months the stock/bond allocation drifts according to
+    realised returns. On rebalance months the allocation snaps back to the
+    target.  When rebalance_period == 1 this is mathematically equivalent to
+    the blended-return fast path.
+    """
+    num_periods = len(stock_returns) - num_months + 1
+    successes = 0
+
+    for start_idx in range(num_periods):
+        value = initial_value
+        stock_frac = target_stock_frac
+
+        for i in range(num_months):
+            sr = stock_returns[start_idx + i]
+            br = bond_returns[start_idx + i]
+            blended = stock_frac * sr + (1.0 - stock_frac) * br
+
+            withdrawal = monthly_spending - monthly_cashflows[i]
+            if withdrawal < 0.0:
+                withdrawal = 0.0
+            value = value * blended - withdrawal
+            if value <= 0:
+                break
+
+            # Drift the allocation
+            if blended > 0.0:
+                stock_frac = (stock_frac * sr) / blended
+            # Rebalance on schedule (1-indexed month)
+            if (i + 1) % rebalance_period == 0:
+                stock_frac = target_stock_frac
+
+        if value > 0 and value >= final_value_target:
+            successes += 1
+
+    return successes / num_periods
+
+
 @nb.jit(nopython=True)
 def test_all_periods(portfolio_returns, num_months, initial_value, monthly_spending, monthly_cashflows, final_value_target):
     """
@@ -174,7 +235,8 @@ def calculate_success_rate(df,
                            analysis_start_date='1871-01-01',
                            initial_value=1_000_000,
                            monthly_cashflows=None,
-                           final_value_target=0.0):
+                           final_value_target=0.0,
+                           rebalance_frequency="Monthly"):
     """
     Calculate the success rate for a given withdrawal rate.
     Numba-accelerated version. Should be 500x+ faster than brute force.
@@ -185,10 +247,8 @@ def calculate_success_rate(df,
     analysis_start = pd.to_datetime(analysis_start_date)
     df_filtered = df[df['Date'] >= analysis_start]
 
-    # Calculate portfolio returns
     stock_prices = df_filtered['Real Total Return Price'].values
     bond_prices = df_filtered['Real Total Bond Returns'].values
-    portfolio_returns = compute_portfolio_returns(stock_prices, bond_prices, stock_pct)
     monthly_spending = initial_value * withdrawal_rate / 12
 
     if monthly_cashflows is None:
@@ -198,8 +258,18 @@ def calculate_success_rate(df,
         if len(monthly_cashflows) != num_months:
             raise ValueError("monthly_cashflows length must match num_months")
 
-    # Call the compiled function
-    return test_all_periods(portfolio_returns, num_months, initial_value, monthly_spending, monthly_cashflows, final_value_target)
+    period = frequency_to_period(rebalance_frequency)
+    if period <= 1:
+        # Fast path: blended returns (equivalent to monthly rebalancing)
+        portfolio_returns = compute_portfolio_returns(stock_prices, bond_prices, stock_pct)
+        return test_all_periods(portfolio_returns, num_months, initial_value, monthly_spending, monthly_cashflows, final_value_target)
+    else:
+        # Drift path: track separate asset returns and rebalance periodically
+        stock_returns, bond_returns = compute_separate_returns(stock_prices, bond_prices)
+        return test_all_periods_with_rebalancing(
+            stock_returns, bond_returns, float(stock_pct), period,
+            num_months, initial_value, monthly_spending, monthly_cashflows, final_value_target
+        )
 
 
 def get_spending_rate_for_fixed_success_rate(df,
@@ -212,7 +282,8 @@ def get_spending_rate_for_fixed_success_rate(df,
                                              cashflows=None,
                                              cashflow_start_offset=0,
                                              cashflow_schedule=None,
-                                             final_value_target=0.0):
+                                             final_value_target=0.0,
+                                             rebalance_frequency="Monthly"):
     """
     Compute the annual spending rate such that a historical simulation over periods of the desired length
     yields the desired success rate.
@@ -307,6 +378,7 @@ def get_spending_rate_for_fixed_success_rate(df,
             initial_value,
             monthly_cashflows=monthly_cashflows,
             final_value_target=final_value_target,
+            rebalance_frequency=rebalance_frequency,
         )
 
         # Check if we're within tolerance
@@ -490,10 +562,15 @@ def get_guardrail_withdrawals(
     cashflows = settings.cashflows_for_calculation()
     monthly_cashflows = cashflow_schedule_for_window(cashflows, total_months, 0)
 
-    # Pre-compute portfolio returns for the entire historical period (for speed)
+    # Pre-compute separate asset returns for the entire historical period
     all_stock_prices = df['Real Total Return Price'].values
     all_bond_prices = df['Real Total Bond Returns'].values
-    portfolio_returns = compute_portfolio_returns(all_stock_prices, all_bond_prices, settings.stock_pct)
+    all_stock_returns, all_bond_returns = compute_separate_returns(all_stock_prices, all_bond_prices)
+
+    rebalance_period = frequency_to_period(settings.rebalance_frequency)
+    target_stock_frac = float(settings.stock_pct)
+    current_stock_frac = target_stock_frac
+    fixed_stock_frac = target_stock_frac
 
     # Initialize results storage
     results = []
@@ -556,7 +633,8 @@ def get_guardrail_withdrawals(
                 stock_pct=settings.stock_pct,
                 cashflows=cashflows,
                 cashflow_schedule=schedule_slice,
-                final_value_target=settings.final_value_target
+                final_value_target=settings.final_value_target,
+                rebalance_frequency=settings.rebalance_frequency,
             )['spending_rate']
 
         if not guardrail_depleted:
@@ -686,9 +764,31 @@ def get_guardrail_withdrawals(
         if i < len(subset) - 1:
             # Find the index in the full dataset
             full_idx = df[df['Date'] == current_date].index[0]
-            month_return = portfolio_returns[full_idx + 1] if full_idx + 1 < len(portfolio_returns) else 1.0
-            current_portfolio_value *= month_return
-            fixed_portfolio_value *= month_return
+            if full_idx + 1 < len(all_stock_returns):
+                sr = all_stock_returns[full_idx + 1]
+                br = all_bond_returns[full_idx + 1]
+            else:
+                sr = 1.0
+                br = 1.0
+
+            # Guardrail path: apply blended return using current allocation
+            gr_blended = current_stock_frac * sr + (1.0 - current_stock_frac) * br
+            current_portfolio_value *= gr_blended
+            # Drift allocation
+            if gr_blended > 0.0:
+                current_stock_frac = (current_stock_frac * sr) / gr_blended
+
+            # Fixed path: apply blended return using fixed allocation
+            fx_blended = fixed_stock_frac * sr + (1.0 - fixed_stock_frac) * br
+            fixed_portfolio_value *= fx_blended
+            if fx_blended > 0.0:
+                fixed_stock_frac = (fixed_stock_frac * sr) / fx_blended
+
+            # Rebalance on schedule
+            next_date = subset.iloc[i + 1]['Date'] if i + 1 < len(subset) else None
+            if next_date is not None and is_adjustment_month(next_date, settings.rebalance_frequency):
+                current_stock_frac = target_stock_frac
+                fixed_stock_frac = target_stock_frac
 
         # Floor at zero and mark depletion so future months remain at zero
         if current_portfolio_value <= 0:
@@ -758,6 +858,7 @@ def compute_guardrail_guidance_snapshot(
             cashflows=cashflows,
             cashflow_schedule=monthly_cashflows,
             final_value_target=float(settings.final_value_target),
+            rebalance_frequency=settings.rebalance_frequency,
         )
         return float(res["spending_rate"]) if res["spending_rate"] is not None else None
 

--- a/utils.py
+++ b/utils.py
@@ -568,9 +568,17 @@ def get_guardrail_withdrawals(
     all_stock_returns, all_bond_returns = compute_separate_returns(all_stock_prices, all_bond_prices)
 
     rebalance_period = frequency_to_period(settings.rebalance_frequency)
-    target_stock_frac = float(settings.stock_pct)
-    current_stock_frac = target_stock_frac
-    fixed_stock_frac = target_stock_frac
+    final_stock_frac = float(settings.stock_pct)
+    gp_months = settings.glidepath_months
+    gp_initial = float(settings.glidepath_initial_pct)
+
+    def glidepath_target(month_idx):
+        if gp_months <= 0 or month_idx >= gp_months:
+            return final_stock_frac
+        return gp_initial + (final_stock_frac - gp_initial) * (month_idx / gp_months)
+
+    current_stock_frac = glidepath_target(0)
+    fixed_stock_frac = glidepath_target(0)
 
     # Initialize results storage
     results = []
@@ -787,8 +795,8 @@ def get_guardrail_withdrawals(
             # Rebalance on schedule
             next_date = subset.iloc[i + 1]['Date'] if i + 1 < len(subset) else None
             if next_date is not None and is_adjustment_month(next_date, settings.rebalance_frequency):
-                current_stock_frac = target_stock_frac
-                fixed_stock_frac = target_stock_frac
+                current_stock_frac = glidepath_target(i + 1)
+                fixed_stock_frac = glidepath_target(i + 1)
 
         # Floor at zero and mark depletion so future months remain at zero
         if current_portfolio_value <= 0:


### PR DESCRIPTION
For simplicity, the tool currently assumes a fixed allocation throughout the period, and rebalances monthly (essentially there is never any drift). Since real retirees often use an [equity glidepath](https://earlyretirementnow.com/2017/09/13/the-ultimate-guide-to-safe-withdrawal-rates-part-19-equity-glidepaths/) and/or rebalance [less frequently](https://earlyretirementnow.com/2020/08/05/rebalance-swr-series-part-39/) than once a month, this change set adds those capabilities to the tool. However, they come with caveats:

1. In the interest of efficiency, the glidepath is applied only to the current portfolio balance, not the forward-looking simulations (those use a constant allocation at the desired end state), which may be at odds with user expectations.
2. The rebalancing introduces a separate code branch and can be slower to calculate than if monthly rebalancing is selected (since "drift" must be tracked).
3. The glidepath adjustments follow the rebalancing schedule, which again may not be how real retirees run a glidepath - they may e.g. adjust quarterly during the glidepath, but then only rebalance yearly afterwards.

With all of that said, neither of these features is ordinarily going to have a major, material impact on the shape of the withdrawal/spending sequence or the final portfolio balance. So the question is, does it make sense to add the features with caveats well understood, or are these just "features for the sake of features" that can be safely left out to avoid the impression of creating a more comprehensive, powerful simulation than we actually have, and pushing the scope of the tool beyond its intended use case, which is a way to illustrate a concept, not necessarily to advise an individual client?

Closes #45 and #62